### PR TITLE
Add Supabase scene helpers

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/supabase-integration.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/supabase-integration.mdx
@@ -1,0 +1,16 @@
+---
+slug: /@excalidraw/excalidraw/api/supabase
+---
+
+# Supabase integration
+
+The application exposes helpers to save and load scenes using a [Supabase](https://supabase.com/) backend.
+
+```ts
+import { saveToSupabase, loadFromSupabase } from "excalidraw-app/data/supabase";
+```
+
+`saveToSupabase()` returns the created row `id` which you can later use with `loadFromSupabase()` to retrieve the scene.
+
+The helpers expect the environment variables `VITE_APP_SUPABASE_URL` and `VITE_APP_SUPABASE_ANON_KEY` to be defined.
+


### PR DESCRIPTION
## Summary
- add simple helpers to save/load scenes from Supabase
- document how to use the Supabase helpers in the docs

## Testing
- `yarn test:update`

------
https://chatgpt.com/codex/tasks/task_e_68684a6dbe88832eb44e9459a8575b3e